### PR TITLE
chore: bump module Go version to 1.20

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: ['1.19', '1.20']
+        go-version: ['1.20', '1.21']
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.21'
           check-latest: true
       - run: go mod tidy
       - run: git diff --exit-code --
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.21'
           check-latest: true
       - run: go run ./test/images/gen_images.go ./test/images
       - run: git diff --exit-code --
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.21'
           check-latest: true
       - uses: goreleaser/goreleaser-action@v4
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.21'
           check-latest: true
       - uses: goreleaser/goreleaser-action@v4
         with:

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.21'
           check-latest: true
       - uses: golangci/golangci-lint-action@v3
         with:

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -26,4 +26,4 @@ jobs:
           check-latest: true
       - uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.53
+          version: v1.54

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: ['1.19', '1.20']
+        go-version: ['1.20', '1.21']
 
     steps:
       - uses: actions/checkout@v3
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.21'
           check-latest: true
       - uses: goreleaser/goreleaser-action@v4
         with:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sylabs/oci-tools
 
-go 1.19
+go 1.20
 
 require (
 	github.com/google/go-containerregistry v0.16.1


### PR DESCRIPTION
Bump module Go version to 1.20. Advance Go range tested in CI to 1.20-1.21. Bump `golangci-lint` to v1.54.