### PR TITLE
ci: test against Go 1.22

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: ['1.20', '1.21']
+        go-version: ['1.21', '1.22']
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           check-latest: true
       - run: go mod tidy
       - run: git diff --exit-code --
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           check-latest: true
       - run: go run ./test/images/gen_images.go ./test/images
       - run: git diff --exit-code --
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           check-latest: true
       - uses: goreleaser/goreleaser-action@v5
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           check-latest: true
       - uses: goreleaser/goreleaser-action@v5
         with:

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -26,4 +26,4 @@ jobs:
           check-latest: true
       - uses: golangci/golangci-lint-action@v4
         with:
-          version: v1.54
+          version: v1.56

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           check-latest: true
       - uses: golangci/golangci-lint-action@v4
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: ['1.20', '1.21']
+        go-version: ['1.21', '1.22']
 
     steps:
       - uses: actions/checkout@v4
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           check-latest: true
       - uses: goreleaser/goreleaser-action@v5
         with:


### PR DESCRIPTION
Test against Go 1.21 and 1.22. Bump `golangci-lint` to v1.56.