### PR TITLE
chore: bump module to go 1.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sylabs/oci-tools
 
-go 1.20
+go 1.21
 
 require (
 	github.com/google/go-containerregistry v0.19.1

--- a/go.sum
+++ b/go.sum
@@ -75,3 +75,4 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools/v3 v3.0.3 h1:4AuOwCGf4lLR9u3YOe2awrHygurzhO/HeQ6laiA6Sx0=
+gotest.tools/v3 v3.0.3/go.mod h1:Z7Lb0S5l+klDB31fvDQX8ss/FlKDxtlFlw3Oa8Ymbl8=

--- a/pkg/mutate/whiteout_test.go
+++ b/pkg/mutate/whiteout_test.go
@@ -5,7 +5,7 @@
 package mutate
 
 import (
-	"reflect"
+	"maps"
 	"testing"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -58,7 +58,7 @@ func Test_scanAUFSOpaque(t *testing.T) {
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
-			if !reflect.DeepEqual(tt.expectOpaque, opaque) {
+			if !maps.Equal(tt.expectOpaque, opaque) {
 				t.Errorf("opaque directories - expected: %v, got: %v", tt.expectOpaque, opaque)
 			}
 			if fileWhiteout != tt.expectFileWhiteout {

--- a/pkg/sif/layer_test.go
+++ b/pkg/sif/layer_test.go
@@ -94,8 +94,8 @@ func TestLayer_Offset(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if d, err := tt.l.(*sif.Layer).Offset(); err != nil {
 				t.Error(err)
-			} else if got, want := d, tt.wantOffset; !reflect.DeepEqual(got, want) {
-				t.Errorf("got offset %+v, want %+v", got, want)
+			} else if got, want := d, tt.wantOffset; got != want {
+				t.Errorf("got offset %v, want %v", got, want)
 			}
 		})
 	}


### PR DESCRIPTION
Bump module to go 1.21. Replace some usage of `reflect` package.