### PR TITLE
chore: bump golangci-lint to v1.57

### DIFF
--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -26,4 +26,4 @@ jobs:
           check-latest: true
       - uses: golangci/golangci-lint-action@v4
         with:
-          version: v1.56
+          version: v1.57

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,7 @@ linters:
     - bidichk
     - bodyclose
     - contextcheck
+    - copyloopvar
     - decorder
     - dogsled
     - dupl
@@ -38,6 +39,7 @@ linters:
     - grouper
     - ineffassign
     - interfacebloat
+    - intrange
     - lll
     - maintidx
     - mirror

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sylabs/oci-tools
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/google/go-containerregistry v0.19.1

--- a/pkg/mutate/squash_test.go
+++ b/pkg/mutate/squash_test.go
@@ -22,8 +22,6 @@ func TestSquash(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			img, err := Squash(tt.base)
 			if err != nil {

--- a/pkg/mutate/squashfs_test.go
+++ b/pkg/mutate/squashfs_test.go
@@ -160,8 +160,6 @@ func Test_SquashfsLayer(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			if _, err := exec.LookPath(tt.converter); errors.Is(err, exec.ErrNotFound) {
 				t.Skip(err)

--- a/pkg/mutate/whiteout_test.go
+++ b/pkg/mutate/whiteout_test.go
@@ -46,7 +46,6 @@ func Test_scanAUFSOpaque(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			rc, err := tt.layer.Uncompressed()
 			if err != nil {


### PR DESCRIPTION
Bump `golangci-lint` to v1.57. Add `copyloopvar` and `intrange`, which won't come into play until this module adopts Go 1.22 but play nicely with Go 1.21. Drop loop variable usage in (non-parallel) tests, which is safe for Go 1.21 and should ensure `copyloopvar` linter will run cleanly when Go 1.22 is adopted.

Add patch version to `go` directive in `go.mod` (see https://github.com/golang/go/issues/62278).