### PR TITLE
ci: bump golangci-lint to v1.59

### DIFF
--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -26,4 +26,4 @@ jobs:
           check-latest: true
       - uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.57
+          version: v1.59

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,7 @@ linters:
     - dogsled
     - dupl
     - dupword
+    - err113
     - errcheck
     - errchkjson
     - errname
@@ -28,7 +29,6 @@ linters:
     - gocyclo
     - godot
     - godox
-    - goerr113
     - gofumpt
     - goimports
     - gomodguard


### PR DESCRIPTION
Also update linter config to reflect name change of linter `goerr113` to `err113`.