### PR TITLE
chore: bump module to Go 1.22

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: ['~1.21.0', '~1.22.0', '~1.23.0-rc.1']
+        go-version: ['~1.22.0', '~1.23.0']
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -15,9 +15,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '~1.22.0'
-      - run: go mod tidy
-      - run: git diff --exit-code --
+          go-version: '~1.23.0'
+      - run: go mod tidy -diff
 
   check-test-corpus:
     name: Check Test Corpus
@@ -27,7 +26,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '~1.22.0'
+          go-version: '~1.23.0'
       - run: sudo apt-get install -qy squashfs-tools-ng
       - run: go run ./test/images/gen_images.go ./test/images
       - run: git diff --exit-code --
@@ -40,7 +39,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '~1.22.0'
+          go-version: '~1.23.0'
       - uses: goreleaser/goreleaser-action@v6
         with:
           args: check

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v5
         with:
-          go-version: '~1.22.0'
+          go-version: '~1.23.0'
       - uses: goreleaser/goreleaser-action@v6
         with:
           args: release

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '~1.22.0'
+          go-version: '~1.23.0'
       - uses: golangci/golangci-lint-action@v6
         with:
           version: v1.59

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -25,4 +25,4 @@ jobs:
           go-version: '~1.23.0'
       - uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.59
+          version: v1.60

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: ['~1.21.0', '~1.22.0', '~1.23.0-rc.1']
+        go-version: ['~1.22.0', '~1.23.0']
 
     steps:
       - uses: actions/checkout@v4
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '~1.22.0'
+          go-version: '~1.23.0'
       - uses: goreleaser/goreleaser-action@v6
         with:
           args: release --snapshot --skip=publish

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sylabs/oci-tools
 
-go 1.21.0
+go 1.22.0
 
 require (
 	github.com/google/go-containerregistry v0.20.2

--- a/test/images/gen_images.go
+++ b/test/images/gen_images.go
@@ -429,10 +429,10 @@ func generateTARImages(path string) error {
 }
 
 func generateManyLayerImage(path string) error {
-	var ls []v1.Layer
-
 	// Generate 50 unique layers.
-	for i := 0; i < 50; i++ {
+	ls := make([]v1.Layer, 50)
+
+	for i := range len(ls) {
 		layer := []tarEntry{
 			{Typeflag: tar.TypeReg, Name: strconv.Itoa(i)},
 		}
@@ -450,7 +450,7 @@ func generateManyLayerImage(path string) error {
 			return err
 		}
 
-		ls = append(ls, l)
+		ls[i] = l
 	}
 
 	img, err := mutate.AppendLayers(empty.Image, ls...)


### PR DESCRIPTION
Bump module Go version to 1.22, and drop testing against Go 1.21. Bump `golangci-lint` to v1.60.