### PR TITLE
ci: bump golangci-lint to v1.61

### DIFF
--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -25,4 +25,4 @@ jobs:
           go-version: '~1.23.0'
       - uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.60
+          version: v1.61

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,7 +19,6 @@ linters:
     - errname
     - errorlint
     - exhaustive
-    - exportloopref
     - forcetypeassert
     - gochecknoglobals
     - gochecknoinits

--- a/test/images/gen_images.go
+++ b/test/images/gen_images.go
@@ -432,7 +432,7 @@ func generateManyLayerImage(path string) error {
 	// Generate 50 unique layers.
 	ls := make([]v1.Layer, 50)
 
-	for i := range len(ls) {
+	for i := range ls {
 		layer := []tarEntry{
 			{Typeflag: tar.TypeReg, Name: strconv.Itoa(i)},
 		}


### PR DESCRIPTION
Remove deprecated `exportloopref` linter. Accept simplified range recommendation.