### PR TITLE
fix: export no match / multiple match errors

### DIFF
--- a/pkg/sif/image.go
+++ b/pkg/sif/image.go
@@ -24,8 +24,8 @@ type image struct {
 }
 
 var (
-	errNoMatchingImage        = errors.New("no image found matching criteria")
-	errMultipleMatchingImages = errors.New("multiple images match criteria")
+	ErrNoMatch         = errors.New("no match found")
+	ErrMultipleMatches = errors.New("multiple matches found")
 )
 
 // Image returns a single Image stored in f, that is selected by the provided
@@ -42,10 +42,10 @@ func (f *OCIFileImage) Image(m match.Matcher, _ ...Option) (v1.Image, error) {
 		return nil, err
 	}
 	if len(matches) > 1 {
-		return nil, errMultipleMatchingImages
+		return nil, ErrMultipleMatches
 	}
 	if len(matches) == 0 {
-		return nil, errNoMatchingImage
+		return nil, ErrNoMatch
 	}
 
 	d, err := matches[0].Digest()

--- a/pkg/sif/index.go
+++ b/pkg/sif/index.go
@@ -67,11 +67,6 @@ func (f *OCIFileImage) RootIndex() (v1.ImageIndex, error) {
 	}, nil
 }
 
-var (
-	errNoMatchingIndex         = errors.New("no index found matching criteria")
-	errMultipleMatchingIndices = errors.New("multiple indices match criteria")
-)
-
 // Index returns a single ImageIndex stored in f, that is selected by the provided
 // Matcher. If more than one index matches, or no index matches, an error is
 // returned.
@@ -86,10 +81,10 @@ func (f *OCIFileImage) Index(m match.Matcher, _ ...Option) (v1.ImageIndex, error
 		return nil, err
 	}
 	if len(matches) > 1 {
-		return nil, errMultipleMatchingIndices
+		return nil, ErrMultipleMatches
 	}
 	if len(matches) == 0 {
-		return nil, errNoMatchingIndex
+		return nil, ErrNoMatch
 	}
 
 	d, err := matches[0].Digest()


### PR DESCRIPTION
`OCIFileImage.Image` or `OCIFileImage.Index` can fail due to no descriptors, or multiple descriptors, being selected by the provided matcher. The functions return a single image or index only.

These no match / multiple match error cases may require specific action in the caller. For example, when looking for an artifact associated with a container image, which may or may not be present.

Export `ErrNoMatch` and `ErrMultipleMatches`, and use these two errors across the Image and Index functions.

Fixes #94