### PR TITLE
chore: bump `golangci-lint` to v1.62

### DIFF
--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -25,4 +25,4 @@ jobs:
           go-version: '~1.23.0'
       - uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.61
+          version: v1.62

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,6 +36,7 @@ linters:
     - gosimple
     - govet
     - grouper
+    - iface
     - ineffassign
     - interfacebloat
     - intrange
@@ -49,6 +50,7 @@ linters:
     - nonamedreturns
     - prealloc
     - reassign
+    - recvcheck
     - revive
     - staticcheck
     - stylecheck


### PR DESCRIPTION
Add `iface` and `recvcheck` linters.