### PR TITLE
feat: pkg/ociplatform for OCI platform comparison

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/sylabs/oci-tools
 go 1.22.0
 
 require (
+	github.com/containerd/platforms v0.2.1
 	github.com/google/go-containerregistry v0.20.2
 	github.com/opencontainers/image-spec v1.1.0
 	github.com/sebdah/goldie/v2 v2.5.5
@@ -10,6 +11,7 @@ require (
 )
 
 require (
+	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.14.3 // indirect
 	github.com/docker/cli v27.1.1+incompatible // indirect
 	github.com/docker/distribution v2.8.2+incompatible // indirect
@@ -22,8 +24,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/sergi/go-diff v1.2.0 // indirect
-	github.com/sirupsen/logrus v1.9.1 // indirect
-	github.com/stretchr/testify v1.8.2 // indirect
+	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/vbatts/tar-split v0.11.3 // indirect
 	golang.org/x/sync v0.2.0 // indirect
 	golang.org/x/sys v0.28.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,8 @@
 github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
+github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
+github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
+github.com/containerd/platforms v0.2.1 h1:zvwtM3rz2YHPQsF2CHYM8+KtB5dvhISiXh5ZpSBQv6A=
+github.com/containerd/platforms v0.2.1/go.mod h1:XHCb+2/hzowdiut9rkudds9bE5yJ7npe7dG/wG+uFPw=
 github.com/containerd/stargz-snapshotter/estargz v0.14.3 h1:OqlDCK3ZVUO6C3B/5FSkDwbkEETK84kQgEeFwDC+62k=
 github.com/containerd/stargz-snapshotter/estargz v0.14.3/go.mod h1:KY//uOCIkSuNAHhJogcZtrNHdKrA99/FCCRjE3HD36o=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
@@ -40,8 +44,8 @@ github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAm
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
 github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
-github.com/sirupsen/logrus v1.9.1 h1:Ou41VVR3nMWWmTiEUnj0OlsgOSCUFgsPAOl6jRIcVtQ=
-github.com/sirupsen/logrus v1.9.1/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
+github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
@@ -51,8 +55,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
-github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/sylabs/sif/v2 v2.20.2 h1:HGEPzauCHhIosw5o6xmT3jczuKEuaFzSfdjAsH33vYw=
 github.com/sylabs/sif/v2 v2.20.2/go.mod h1:WyYryGRaR4Wp21SAymm5pK0p45qzZCSRiZMFvUZiuhc=
 github.com/urfave/cli v1.22.12/go.mod h1:sSBEIC79qR6OvcmsD4U3KABeOTxDqQtdDnaFuUN30b8=

--- a/pkg/ociplatform/platform.go
+++ b/pkg/ociplatform/platform.go
@@ -1,0 +1,104 @@
+// Copyright 2024-2025 Sylabs Inc. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ociplatform
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/containerd/platforms"
+	ggcrv1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/match"
+	specsv1 "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// specsPlatform converts a ggcr v1.Platform to a specs-go v1.Platform.
+func specsPlatform(p ggcrv1.Platform) specsv1.Platform {
+	return specsv1.Platform{
+		Architecture: p.Architecture,
+		OS:           p.OS,
+		OSVersion:    p.OSVersion,
+		OSFeatures:   p.OSFeatures,
+		Variant:      p.Variant,
+	}
+}
+
+// ggcrPlatform converts a specs-go v1.Platform to a ggcr v1.Platform.
+func ggcrPlatform(p specsv1.Platform) ggcrv1.Platform {
+	return ggcrv1.Platform{
+		Architecture: p.Architecture,
+		OS:           p.OS,
+		OSVersion:    p.OSVersion,
+		OSFeatures:   p.OSFeatures,
+		Variant:      p.Variant,
+	}
+}
+
+// DefaultPlatform returns the local machine's platform as a ggcr v1.Platform.
+func DefaultPlatform() *ggcrv1.Platform {
+	dp := ggcrPlatform(platforms.DefaultSpec())
+	return &dp
+}
+
+// ImageSatisfies returns true if img satisfies platform, using the
+// containerd/platforms matcher, which applies normalization rules. If an image
+// has no platform, then it is considered to satisfy any platform specification.
+func ImageSatisfies(img ggcrv1.Image, platform ggcrv1.Platform) (bool, error) {
+	cf, err := img.ConfigFile()
+	if err != nil {
+		return false, err
+	}
+
+	cfp := cf.Platform()
+	if cfp == nil {
+		return true, nil
+	}
+
+	imgPlatform := specsPlatform(*cfp)
+	targetPlatform := specsPlatform(platform)
+	m := platforms.NewMatcher(targetPlatform)
+	return m.Match(imgPlatform), nil
+}
+
+var ErrPlatformNotSatisfied = errors.New("image does not satisfy platform")
+
+// EnsureImageSatisfies returns an error if img does not satisfy platform, using
+// the containerd/platforms matcher, which applies normalization rules.
+func EnsureImageSatisfies(img ggcrv1.Image, platform ggcrv1.Platform) error {
+	ok, err := ImageSatisfies(img, platform)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("%w: %s", ErrPlatformNotSatisfied, platform.String())
+	}
+	return nil
+}
+
+// DescriptorSatisfies returns true if desc satisfies platform, using the
+// containerd/platforms matcher, which applies normalization rules. If a
+// descriptor has no platform, then it is considered to satisfy any platform
+// specification.
+func DescriptorSatisfies(desc ggcrv1.Descriptor, platform ggcrv1.Platform) bool {
+	if desc.Platform == nil {
+		return true
+	}
+
+	descPlatform := specsPlatform(*desc.Platform)
+	targetPlatform := specsPlatform(platform)
+	m := platforms.NewMatcher(targetPlatform)
+	return m.Match(descPlatform)
+}
+
+// Matcher returns a ggcr matcher that selects images matching platform p (using
+// containerd/platform matching rules) and non-image descriptors.
+func Matcher(p *ggcrv1.Platform) match.Matcher {
+	return func(desc ggcrv1.Descriptor) bool {
+		if p != nil && desc.MediaType.IsImage() {
+			return DescriptorSatisfies(desc, *p)
+		}
+		return true
+	}
+}


### PR DESCRIPTION
OCI platform handling in ggcr is sometimes incomplete / naive. For example, handling of the variant is not consistent with the normalisation rules that are applied in e.g. Docker, containerd etc.

Add functions in a new `pkg/ociplatform` package that perform platform comparison using `github.com/containerd/platforms`, with translation through ggcr <-> spec-go types as necessary.