### PR TITLE
lint: bump `golangci-lint` to v1.63

### DIFF
--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -25,4 +25,4 @@ jobs:
           go-version: '~1.23.0'
       - uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.62
+          version: v1.63

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,6 +19,7 @@ linters:
     - errname
     - errorlint
     - exhaustive
+    - exptostd
     - forcetypeassert
     - gochecknoglobals
     - gochecknoinits
@@ -45,6 +46,7 @@ linters:
     - mirror
     - misspell
     - nakedret
+    - nilnesserr
     - noctx
     - nolintlint
     - nonamedreturns
@@ -60,4 +62,5 @@ linters:
     - unconvert
     - unparam
     - unused
+    - usetesting
     - whitespace


### PR DESCRIPTION
Enable `exptostd`, `nilnesserr` and `usetesting` linters.