### PR TITLE
chore: bump module to Go 1.23

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: ['~1.22.0', '~1.23.0', '~1.24.0-rc.1']
+        go-version: ['~1.23.0', '~1.24.0']
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '~1.23.0'
+          go-version: '~1.24.0'
       - run: go mod tidy -diff
 
   check-test-corpus:
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '~1.23.0'
+          go-version: '~1.24.0'
       - run: sudo apt-get install -qy squashfs-tools-ng
       - run: go run ./test/images/gen_images.go ./test/images
       - run: git diff --exit-code --
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '~1.23.0'
+          go-version: '~1.24.0'
       - uses: goreleaser/goreleaser-action@v6
         with:
           args: check

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v5
         with:
-          go-version: '~1.23.0'
+          go-version: '~1.24.0'
       - uses: goreleaser/goreleaser-action@v6
         with:
           args: release

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '~1.23.0'
+          go-version: '~1.24.0'
       - uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.63
+          version: v1.64

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: ['~1.22.0', '~1.23.0', '~1.24.0-rc.1']
+        go-version: ['~1.23.0', '~1.24.0']
 
     steps:
       - uses: actions/checkout@v4
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '~1.23.0'
+          go-version: '~1.24.0'
       - uses: goreleaser/goreleaser-action@v6
         with:
           args: release --snapshot --skip=publish

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sylabs/oci-tools
 
-go 1.22.7
+go 1.23.0
 
 require (
 	github.com/containerd/platforms v0.2.1


### PR DESCRIPTION
Bump module Go version to 1.23, and drop testing against Go 1.22. Bump `golangci-lint` to v1.64 to ensure Go 1.24 compatibility.