### PR TITLE
chore: bump module to Go 1.24

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: ['~1.23.0', '~1.24.0']
+        go-version: ['~1.24.0', '~1.25.0']
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
-          go-version: '~1.24.0'
+          go-version: '~1.25.0'
       - run: go mod tidy -diff
 
   check-test-corpus:
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
-          go-version: '~1.24.0'
+          go-version: '~1.25.0'
       - run: sudo apt-get install -qy squashfs-tools-ng
       - run: go run ./test/images/gen_images.go ./test/images
       - run: git diff --exit-code --
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
-          go-version: '~1.24.0'
+          go-version: '~1.25.0'
       - uses: goreleaser/goreleaser-action@v6
         with:
           args: check

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v5
         with:
-          go-version: '~1.24.0'
+          go-version: '~1.25.0'
       - uses: goreleaser/goreleaser-action@v6
         with:
           args: release

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
-          go-version: '~1.24.0'
+          go-version: '~1.25.0'
       - uses: golangci/golangci-lint-action@v8
         with:
           version: v2.2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: ['~1.23.0', '~1.24.0']
+        go-version: ['~1.24.0', '~1.25.0']
 
     steps:
       - uses: actions/checkout@v5
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
-          go-version: '~1.24.0'
+          go-version: '~1.25.0'
       - uses: goreleaser/goreleaser-action@v6
         with:
           args: release --snapshot --skip=publish

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sylabs/oci-tools
 
-go 1.23.4
+go 1.24.0
 
 require (
 	github.com/containerd/platforms v0.2.1

--- a/pkg/sourcesink/cosign_sif_test.go
+++ b/pkg/sourcesink/cosign_sif_test.go
@@ -5,7 +5,6 @@
 package sourcesink
 
 import (
-	"context"
 	"testing"
 
 	cosignoci "github.com/sigstore/cosign/v2/pkg/oci"
@@ -43,7 +42,7 @@ func Test_sifDescriptor_CosignImages(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			d, err := s.Get(context.Background())
+			d, err := s.Get(t.Context())
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -53,7 +52,7 @@ func Test_sifDescriptor_CosignImages(t *testing.T) {
 				t.Fatal("could not upgrade Descriptor to SignedDescriptor")
 			}
 
-			got, err := sd.CosignImages(context.Background(), tt.recursive)
+			got, err := sd.CosignImages(t.Context(), tt.recursive)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -93,7 +92,7 @@ func Test_sifDescriptor_SignedImage(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			d, err := s.Get(context.Background())
+			d, err := s.Get(t.Context())
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -103,7 +102,7 @@ func Test_sifDescriptor_SignedImage(t *testing.T) {
 				t.Fatal("could not upgrade Descriptor to SignedDescriptor")
 			}
 
-			si, err := sd.SignedImage(context.Background())
+			si, err := sd.SignedImage(t.Context())
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -167,7 +166,7 @@ func Test_sifDescriptor_SignedImageIndex(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			d, err := s.Get(context.Background())
+			d, err := s.Get(t.Context())
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -177,7 +176,7 @@ func Test_sifDescriptor_SignedImageIndex(t *testing.T) {
 				t.Fatal("could not upgrade Descriptor to SignedDescriptor")
 			}
 
-			sii, err := sd.SignedImageIndex(context.Background())
+			sii, err := sd.SignedImageIndex(t.Context())
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/sourcesink/sif_test.go
+++ b/pkg/sourcesink/sif_test.go
@@ -5,7 +5,6 @@
 package sourcesink
 
 import (
-	"context"
 	"errors"
 	"io"
 	"log/slog"
@@ -128,7 +127,7 @@ func TestSIFGet(t *testing.T) {
 			if err != nil {
 				t.Fatalf("SIFFromPath() error = %v", err)
 			}
-			d, err := s.Get(context.Background(), tt.opts...)
+			d, err := s.Get(t.Context(), tt.opts...)
 			if !errors.Is(err, tt.wantErr) {
 				t.Fatalf("Get() error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -170,7 +169,7 @@ func TestSIFDescriptorImage(t *testing.T) {
 			if err != nil {
 				t.Fatalf("SIFFromPath() error = %v", err)
 			}
-			d, err := s.Get(context.Background())
+			d, err := s.Get(t.Context())
 			if err != nil {
 				t.Fatalf(".Get() error = %v", err)
 			}
@@ -210,7 +209,7 @@ func TestSIFDescriptorImageIndex(t *testing.T) {
 			if err != nil {
 				t.Fatalf("SIFFromPath() error = %v", err)
 			}
-			d, err := s.Get(context.Background())
+			d, err := s.Get(t.Context())
 			if err != nil {
 				t.Fatalf(".Get() error = %v", err)
 			}
@@ -289,7 +288,7 @@ func TestSIFWrite(t *testing.T) {
 			if err != nil {
 				t.Fatalf("SIFEmpty() error = %v", err)
 			}
-			err = s.Write(context.Background(), tt.write, tt.opts...)
+			err = s.Write(t.Context(), tt.write, tt.opts...)
 			if err != nil {
 				t.Fatalf(".Write() error = %v", err)
 			}
@@ -356,7 +355,7 @@ func TestSIFBlob(t *testing.T) {
 			if err != nil {
 				t.Fatalf("OCIFromPath() error = %v", err)
 			}
-			rc, err := s.Blob(context.Background(), tt.opts...)
+			rc, err := s.Blob(t.Context(), tt.opts...)
 			if !errors.Is(err, tt.wantErr) {
 				t.Fatalf("Get() error = %v, wantErr %v", err, tt.wantErr)
 			}


### PR DESCRIPTION
Bump module Go version to 1.24, and drop testing against Go 1.23.