### PR TITLE
chore: bump `golangci-lint` to v2.4

### DIFF
--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -25,4 +25,4 @@ jobs:
           go-version: '~1.25.0'
       - uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.3
+          version: v2.4

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -25,4 +25,4 @@ jobs:
           go-version: '~1.25.0'
       - uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.2
+          version: v2.3

--- a/pkg/mutate/squashfs_test.go
+++ b/pkg/mutate/squashfs_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Sylabs Inc. All rights reserved.
+// Copyright 2023-2025 Sylabs Inc. All rights reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -39,7 +39,7 @@ func diffSquashFS(tb testing.TB, pathA, pathB string, diffArgs ...string) {
 	args := []string{"-a", pathA, "-b", pathB}
 	args = append(args, diffArgs...)
 
-	cmd := exec.Command("sqfsdiff", args...)
+	cmd := exec.CommandContext(tb.Context(), "sqfsdiff", args...)
 
 	if out, err := cmd.CombinedOutput(); err != nil {
 		tb.Log(string(out))

--- a/pkg/mutate/tar.go
+++ b/pkg/mutate/tar.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Sylabs Inc. All rights reserved.
+// Copyright 2024-2025 Sylabs Inc. All rights reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -6,6 +6,7 @@ package mutate
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -19,6 +20,7 @@ type tarConverter struct {
 	converter       string // Path to converter program.
 	dir             string // Working directory.
 	convertWhiteout bool   // Convert whiteout markers from OverlayFS -> AUFS
+	ctx             context.Context
 }
 
 // TarConverterOpt are used to specify tar converter options.
@@ -83,6 +85,7 @@ func TarFromSquashfsLayer(base v1.Layer, opts ...TarConverterOpt) (tarball.Opene
 
 	c := tarConverter{
 		convertWhiteout: true,
+		ctx:             context.Background(),
 	}
 
 	for _, opt := range opts {
@@ -121,7 +124,7 @@ func (c *tarConverter) makeTAR(r io.Reader) (io.ReadCloser, error) {
 
 	pr, pw := io.Pipe()
 	//nolint:gosec // Arguments are created programatically.
-	cmd := exec.Command(c.converter, sqfsFile.Name())
+	cmd := exec.CommandContext(c.ctx, c.converter, sqfsFile.Name())
 	cmd.Stdout = pw
 	errBuff := bytes.Buffer{}
 	cmd.Stderr = &errBuff


### PR DESCRIPTION
Address new lint by replacing `exec.Command` with `exec.CommandContext`.