### PR TITLE
chore: bump `golangci-lint` to v2.12

### DIFF
--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -25,4 +25,4 @@ jobs:
           go-version: '~1.26.0'
       - uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee #v9.2.1
         with:
-          version: v2.9
+          version: v2.12

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,7 +28,7 @@ linters:
     - gocyclo
     - godot
     - godox
-    - gomodguard
+    - gomodguard_v2
     - goprintffuncname
     - gosec
     - govet
@@ -63,6 +63,9 @@ linters:
       - common-false-positives
       - legacy
       - std-error-handling
+  settings:
+    goconst:
+      ignore-tests: true
 
 formatters:
   enable:

--- a/test/images/gen_images.go
+++ b/test/images/gen_images.go
@@ -166,6 +166,7 @@ func generateTARImages(path string) error {
 		//	a/b
 		//	a/b/bar
 		{
+			//nolint:goconst
 			layers: [][]tarEntry{
 				{
 					{Typeflag: tar.TypeDir, Name: "a/"},
@@ -186,6 +187,7 @@ func generateTARImages(path string) error {
 		//	a/
 		//	a/bar
 		{
+			//nolint:goconst
 			layers: [][]tarEntry{
 				{
 					{Typeflag: tar.TypeDir, Name: "a/"},


### PR DESCRIPTION
Remove deprecated linter and ignore lint in tests/`gen-images`.